### PR TITLE
feat: implement initial ros2launch_session package

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+Any contribution that you make to this repository will
+be under the Apache 2 License, as dictated by that
+[license](http://www.apache.org/licenses/LICENSE-2.0.html):
+
+~~~
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+~~~

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>ros2launch_session</name>
+  <version>0.0.0</version>
+  <description>Managed ROS 2 launch sessions for reliable startup, monitoring, and shutdown</description>
+  <maintainer email="roland@ccom.unh.edu">Roland Arsenault</maintainer>
+  <license>Apache-2.0</license>
+
+  <depend>launch</depend>
+  <depend>launch_testing</depend>
+
+  <test_depend>ament_copyright</test_depend>
+  <test_depend>ament_flake8</test_depend>
+  <test_depend>ament_pep257</test_depend>
+  <test_depend>python3-pytest</test_depend>
+
+  <export>
+    <build_type>ament_python</build_type>
+  </export>
+</package>

--- a/ros2launch_session/__init__.py
+++ b/ros2launch_session/__init__.py
@@ -1,0 +1,19 @@
+# Copyright 2025 University of New Hampshire, Center for Coastal and Ocean Mapping
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Managed ROS 2 launch sessions for reliable startup, monitoring, and shutdown."""
+
+from .launch_session import LaunchSession
+
+__all__ = ['LaunchSession']

--- a/ros2launch_session/launch_session.py
+++ b/ros2launch_session/launch_session.py
@@ -1,0 +1,268 @@
+# Copyright 2025 University of New Hampshire, Center for Coastal and Ocean Mapping
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Managed ROS 2 launch sessions for reliable startup, monitoring, and shutdown."""
+
+import contextlib
+import threading
+
+import launch
+import launch.actions
+import launch.event_handlers
+import launch.events
+
+from launch_testing.io_handler import ActiveIoHandler
+from launch_testing.proc_info_handler import ActiveProcInfoHandler
+from launch_testing.tools.process import ProcessProxy
+
+
+class LaunchSession:
+    """
+    A managed launch session that provides reliable process lifecycle control.
+
+    Composes existing ``launch`` and ``launch_testing`` APIs to provide:
+    - Thread-safe process startup/shutdown monitoring
+    - Output capture and pattern matching
+    - Clean shutdown via LaunchService's SIGINT/SIGTERM/SIGKILL escalation
+
+    Two usage modes:
+
+    **Standalone mode** — owns the LaunchService, blocks on ``run()``:
+
+    .. code-block:: python
+
+        session = LaunchSession(my_launch_description)
+        exit_code = session.run(on_ready=my_callback)
+
+    **External service mode** — borrows an existing LaunchService:
+
+    .. code-block:: python
+
+        with LaunchSession.from_service(launch_service, my_ld) as session:
+            session.wait_for_startup('my_node')
+            # interact with the system...
+    """
+
+    def __init__(self, launch_description, *, noninteractive=True, debug=False):
+        """
+        Create a managed launch session.
+
+        :param launch_description: The LaunchDescription to manage.
+        :param noninteractive: If True (default), disable interactive features.
+        :param debug: If True, enable debug output in the LaunchService.
+        """
+        self._launch_service = launch.LaunchService(
+            noninteractive=noninteractive, debug=debug
+        )
+        self._proc_info = ActiveProcInfoHandler()
+        self._proc_output = ActiveIoHandler()
+        self._owns_service = True
+
+        self._wrapped_ld = self._wrap_launch_description(launch_description)
+
+    @classmethod
+    def _create_borrowed(cls, launch_service):
+        """Create a session that borrows an existing LaunchService."""
+        session = cls.__new__(cls)
+        session._launch_service = launch_service
+        session._proc_info = ActiveProcInfoHandler()
+        session._proc_output = ActiveIoHandler()
+        session._owns_service = False
+        session._wrapped_ld = None
+        return session
+
+    def _wrap_launch_description(self, launch_description):
+        """
+        Wrap a launch description with process tracking event handlers.
+
+        This is the 4-handler pattern from launch_testing's _RunnerWorker.run().
+        """
+        return launch.LaunchDescription([
+            launch.actions.RegisterEventHandler(
+                launch.event_handlers.OnProcessStart(
+                    on_start=lambda info, unused: self._proc_info.append(info)
+                )
+            ),
+            launch.actions.RegisterEventHandler(
+                launch.event_handlers.OnProcessStart(
+                    on_start=lambda info, unused: self._proc_output.track(
+                        info.process_name
+                    )
+                )
+            ),
+            launch.actions.RegisterEventHandler(
+                launch.event_handlers.OnProcessExit(
+                    on_exit=lambda info, unused: self._proc_info.append(info)
+                )
+            ),
+            launch.actions.RegisterEventHandler(
+                launch.event_handlers.OnProcessIO(
+                    on_stdout=self._proc_output.append,
+                    on_stderr=self._proc_output.append,
+                )
+            ),
+            launch.actions.IncludeLaunchDescription(
+                launch.LaunchDescriptionSource(
+                    launch_description=launch_description
+                )
+            ),
+        ])
+
+    def run(self, on_ready=None, *, shutdown_when_idle=True):
+        """
+        Run the launch session, blocking until completion.
+
+        Must be called from the main thread (LaunchService constraint).
+
+        :param on_ready: Optional callback receiving this session. Called on a
+            daemon thread immediately after the launch service starts processing.
+            The callback should call ``shutdown()`` when done (a ``finally`` block
+            ensures shutdown if the callback raises).
+        :param shutdown_when_idle: If True (default), the launch service shuts
+            down when all processes have exited.
+        :returns: The launch service exit code.
+        """
+        if not self._owns_service:
+            raise RuntimeError(
+                'Cannot call run() on a session created with from_service(). '
+                'The external LaunchService owns the event loop.'
+            )
+
+        self._launch_service.include_launch_description(self._wrapped_ld)
+
+        if on_ready is not None:
+            thread = threading.Thread(
+                target=self._run_callback, args=(on_ready,), daemon=True
+            )
+            thread.start()
+
+        return self._launch_service.run(
+            shutdown_when_idle=shutdown_when_idle
+        )
+
+    def _run_callback(self, on_ready):
+        """Run the on_ready callback, ensuring shutdown on completion."""
+        try:
+            on_ready(self)
+        finally:
+            self.shutdown()
+
+    def shutdown(self, *, reason='session complete'):
+        """
+        Shut down the launch session.
+
+        Thread-safe. Triggers LaunchService's existing SIGINT → SIGTERM → SIGKILL
+        escalation for all managed processes. Idempotent.
+
+        :param reason: Human-readable shutdown reason (for logging).
+        """
+        ret = self._launch_service.shutdown()
+        if ret is not None:
+            # shutdown() returned a coroutine (called from within the event loop),
+            # but we don't await it here — LaunchService handles it internally
+            pass
+
+    def wait_for_startup(self, process, *, timeout=10):
+        """
+        Block until a process starts.
+
+        :param process: Process name or ExecuteProcess action.
+        :param timeout: Seconds to wait before raising AssertionError.
+        :raises AssertionError: If the process doesn't start within timeout.
+        """
+        self._proc_info.assertWaitForStartup(process, timeout=timeout)
+
+    def wait_for_shutdown(self, process, *, timeout=10):
+        """
+        Block until a process exits.
+
+        :param process: Process name or ExecuteProcess action.
+        :param timeout: Seconds to wait before raising AssertionError.
+        :raises AssertionError: If the process doesn't exit within timeout.
+        """
+        self._proc_info.assertWaitForShutdown(process, timeout=timeout)
+
+    def wait_for_output(self, expected, *, process=None, timeout=10,
+                        stream='stderr'):
+        """
+        Block until expected output appears.
+
+        :param expected: Text to search for in process output.
+        :param process: Process name to filter by, or None for all processes.
+        :param timeout: Seconds to wait before raising AssertionError.
+        :param stream: Output stream to search ('stderr' or 'stdout').
+        :raises AssertionError: If the output doesn't appear within timeout.
+        """
+        self._proc_output.assertWaitFor(
+            expected, process=process, timeout=timeout, stream=stream
+        )
+
+    def get_proxy(self, process_action, **kwargs):
+        """
+        Get a ProcessProxy for fine-grained process control.
+
+        :param process_action: An ExecuteProcess action to proxy.
+        :param kwargs: Additional arguments forwarded to ProcessProxy.
+        :returns: A ProcessProxy instance.
+        """
+        return ProcessProxy(
+            process_action, self._proc_info, self._proc_output, **kwargs
+        )
+
+    @property
+    def proc_info(self):
+        """Get the ActiveProcInfoHandler tracking process lifecycle events."""
+        return self._proc_info
+
+    @property
+    def proc_output(self):
+        """Get the ActiveIoHandler capturing process output."""
+        return self._proc_output
+
+    @property
+    def launch_service(self):
+        """Get the underlying LaunchService."""
+        return self._launch_service
+
+    @classmethod
+    @contextlib.contextmanager
+    def from_service(cls, launch_service, launch_description):
+        """
+        Use within an existing LaunchService context.
+
+        Creates a session that borrows the given LaunchService (does not create
+        a new one). The launch description is injected via ``emit_event()`` and
+        the session is yielded for interaction.
+
+        On context exit, calls ``shutdown()`` if processes are still running.
+
+        :param launch_service: An already-running LaunchService.
+        :param launch_description: The LaunchDescription to manage.
+        :yields: A LaunchSession instance.
+        """
+        session = cls._create_borrowed(launch_service)
+        wrapped_ld = session._wrap_launch_description(launch_description)
+
+        launch_service.emit_event(
+            launch.events.IncludeLaunchDescription(
+                launch_description=wrapped_ld
+            )
+        )
+
+        try:
+            yield session
+        finally:
+            process_names = session._proc_info.process_names()
+            if process_names:
+                session.shutdown()

--- a/ros2launch_session/launch_session.py
+++ b/ros2launch_session/launch_session.py
@@ -69,6 +69,9 @@ class LaunchSession:
         self._proc_output = ActiveIoHandler()
         self._owns_service = True
 
+        self._callback_error = None
+        self._has_run = False
+
         self._wrapped_ld = self._wrap_launch_description(launch_description)
 
     @classmethod
@@ -79,6 +82,8 @@ class LaunchSession:
         session._proc_info = ActiveProcInfoHandler()
         session._proc_output = ActiveIoHandler()
         session._owns_service = False
+        session._callback_error = None
+        session._has_run = False
         session._wrapped_ld = None
         return session
 
@@ -139,6 +144,13 @@ class LaunchSession:
                 'The external LaunchService owns the event loop.'
             )
 
+        if self._has_run:
+            raise RuntimeError(
+                'run() has already been called on this session. '
+                'Create a new LaunchSession to run again.'
+            )
+        self._has_run = True
+
         self._launch_service.include_launch_description(self._wrapped_ld)
 
         if on_ready is not None:
@@ -147,31 +159,32 @@ class LaunchSession:
             )
             thread.start()
 
-        return self._launch_service.run(
+        exit_code = self._launch_service.run(
             shutdown_when_idle=shutdown_when_idle
         )
+
+        if self._callback_error is not None:
+            raise self._callback_error
+
+        return exit_code
 
     def _run_callback(self, on_ready):
         """Run the on_ready callback, ensuring shutdown on completion."""
         try:
             on_ready(self)
+        except Exception as e:
+            self._callback_error = e
         finally:
             self.shutdown()
 
-    def shutdown(self, *, reason='session complete'):
+    def shutdown(self):
         """
         Shut down the launch session.
 
         Thread-safe. Triggers LaunchService's existing SIGINT → SIGTERM → SIGKILL
         escalation for all managed processes. Idempotent.
-
-        :param reason: Human-readable shutdown reason (for logging).
         """
-        ret = self._launch_service.shutdown()
-        if ret is not None:
-            # shutdown() returned a coroutine (called from within the event loop),
-            # but we don't await it here — LaunchService handles it internally
-            pass
+        self._launch_service.shutdown()
 
     def wait_for_startup(self, process, *, timeout=10):
         """
@@ -247,7 +260,8 @@ class LaunchSession:
 
         On context exit, calls ``shutdown()`` if processes are still running.
 
-        :param launch_service: An already-running LaunchService.
+        :param launch_service: A LaunchService instance (caller is responsible
+            for running it, typically on another thread).
         :param launch_description: The LaunchDescription to manage.
         :yields: A LaunchSession instance.
         """

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+[develop]
+script_dir=$base/lib/ros2launch_session
+[install]
+install_scripts=$base/lib/ros2launch_session

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,21 @@
+from setuptools import find_packages, setup
+
+package_name = 'ros2launch_session'
+
+setup(
+    name=package_name,
+    version='0.0.0',
+    packages=find_packages(exclude=['test']),
+    data_files=[
+        ('share/ament_index/resource_index/packages',
+            ['resource/' + package_name]),
+        ('share/' + package_name, ['package.xml']),
+    ],
+    install_requires=['setuptools'],
+    zip_safe=True,
+    maintainer='Roland Arsenault',
+    maintainer_email='roland@ccom.unh.edu',
+    description='Managed ROS 2 launch sessions for reliable startup, monitoring, and shutdown',
+    license='Apache-2.0',
+    tests_require=['pytest'],
+)

--- a/test/test_copyright.py
+++ b/test/test_copyright.py
@@ -1,0 +1,23 @@
+# Copyright 2025 University of New Hampshire, Center for Coastal and Ocean Mapping
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_copyright.main import main
+import pytest
+
+
+@pytest.mark.copyright
+@pytest.mark.linter
+def test_copyright():
+    rc = main(argv=['.', 'test'])
+    assert rc == 0, 'Found errors'

--- a/test/test_flake8.py
+++ b/test/test_flake8.py
@@ -1,0 +1,25 @@
+# Copyright 2025 University of New Hampshire, Center for Coastal and Ocean Mapping
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_flake8.main import main_with_errors
+import pytest
+
+
+@pytest.mark.flake8
+@pytest.mark.linter
+def test_flake8():
+    rc, errors = main_with_errors(argv=[])
+    assert rc == 0, \
+        'Found %d code style errors / warnings:\n' % len(errors) + \
+        '\n'.join(errors)

--- a/test/test_launch_session.py
+++ b/test/test_launch_session.py
@@ -14,6 +14,8 @@
 
 """Functional tests for LaunchSession."""
 
+import threading
+
 import launch
 import launch.actions
 import pytest
@@ -43,7 +45,7 @@ def test_shutdown_long_running_process():
     """Verify that shutdown() terminates a long-running process cleanly."""
     ld = launch.LaunchDescription([
         launch.actions.ExecuteProcess(
-            cmd=['sleep', '300'],
+            cmd=['sleep', '60'],
         ),
     ])
 
@@ -66,3 +68,94 @@ def test_run_not_allowed_on_borrowed_service():
     with pytest.raises(RuntimeError, match='Cannot call run'):
         with LaunchSession.from_service(ls, ld) as session:
             session.run()
+
+
+def test_wait_for_shutdown():
+    """Verify wait_for_shutdown() returns after a short-lived process exits."""
+    ld = launch.LaunchDescription([
+        launch.actions.ExecuteProcess(
+            cmd=['echo', 'done'],
+            output='both',
+        ),
+    ])
+
+    session = LaunchSession(ld)
+
+    def on_ready(s):
+        s.wait_for_shutdown('echo', timeout=10)
+
+    exit_code = session.run(on_ready=on_ready)
+    assert exit_code == 0
+
+
+def test_from_service_with_running_service():
+    """Verify from_service() works with a LaunchService running on the main thread."""
+    ls = launch.LaunchService(noninteractive=True)
+
+    # Include an empty launch description so the service has something to start with
+    ls.include_launch_description(launch.LaunchDescription([]))
+
+    errors = []
+
+    def worker():
+        try:
+            ld = launch.LaunchDescription([
+                launch.actions.ExecuteProcess(
+                    cmd=['echo', 'from_service test'],
+                    output='both',
+                ),
+            ])
+
+            with LaunchSession.from_service(ls, ld) as session:
+                session.wait_for_output(
+                    'from_service test', timeout=10, stream='stdout'
+                )
+                session.wait_for_shutdown('echo', timeout=10)
+        except Exception as e:
+            errors.append(e)
+        finally:
+            ls.shutdown()
+
+    thread = threading.Thread(target=worker, daemon=True)
+    thread.start()
+
+    # run() must be called from the main thread
+    ls.run(shutdown_when_idle=False)
+    thread.join(timeout=5)
+
+    if errors:
+        raise errors[0]
+
+
+def test_run_twice_raises():
+    """Verify that calling run() a second time raises RuntimeError."""
+    ld = launch.LaunchDescription([
+        launch.actions.ExecuteProcess(
+            cmd=['echo', 'once'],
+            output='both',
+        ),
+    ])
+
+    session = LaunchSession(ld)
+    session.run()
+
+    with pytest.raises(RuntimeError, match='already been called'):
+        session.run()
+
+
+def test_callback_error_propagation():
+    """Verify that exceptions from on_ready callbacks are re-raised by run()."""
+    ld = launch.LaunchDescription([
+        launch.actions.ExecuteProcess(
+            cmd=['sleep', '10'],
+        ),
+    ])
+
+    session = LaunchSession(ld)
+
+    def on_ready(s):
+        s.wait_for_startup('sleep', timeout=5)
+        raise ValueError('test error from callback')
+
+    with pytest.raises(ValueError, match='test error from callback'):
+        session.run(on_ready=on_ready)

--- a/test/test_launch_session.py
+++ b/test/test_launch_session.py
@@ -1,0 +1,68 @@
+# Copyright 2025 University of New Hampshire, Center for Coastal and Ocean Mapping
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Functional tests for LaunchSession."""
+
+import launch
+import launch.actions
+import pytest
+
+from ros2launch_session import LaunchSession
+
+
+def test_echo_and_shutdown():
+    """Verify that a simple echo command runs, output is captured, and exits cleanly."""
+    ld = launch.LaunchDescription([
+        launch.actions.ExecuteProcess(
+            cmd=['echo', 'hello launch session'],
+            output='both',
+        ),
+    ])
+
+    session = LaunchSession(ld)
+
+    def on_ready(s):
+        s.wait_for_output('hello launch session', timeout=10, stream='stdout')
+
+    exit_code = session.run(on_ready=on_ready)
+    assert exit_code == 0
+
+
+def test_shutdown_long_running_process():
+    """Verify that shutdown() terminates a long-running process cleanly."""
+    ld = launch.LaunchDescription([
+        launch.actions.ExecuteProcess(
+            cmd=['sleep', '300'],
+        ),
+    ])
+
+    session = LaunchSession(ld)
+
+    def on_ready(s):
+        s.wait_for_startup('sleep', timeout=10)
+        s.shutdown()
+
+    exit_code = session.run(on_ready=on_ready)
+    # Exit code is non-zero because sleep was killed
+    assert exit_code is not None
+
+
+def test_run_not_allowed_on_borrowed_service():
+    """Verify that run() raises on a borrowed-service session."""
+    ls = launch.LaunchService(noninteractive=True)
+    ld = launch.LaunchDescription([])
+
+    with pytest.raises(RuntimeError, match='Cannot call run'):
+        with LaunchSession.from_service(ls, ld) as session:
+            session.run()

--- a/test/test_pep257.py
+++ b/test/test_pep257.py
@@ -1,0 +1,23 @@
+# Copyright 2025 University of New Hampshire, Center for Coastal and Ocean Mapping
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ament_pep257.main import main
+import pytest
+
+
+@pytest.mark.linter
+@pytest.mark.pep257
+def test_pep257():
+    rc = main(argv=['.', 'test'])
+    assert rc == 0, 'Found code style errors / warnings'


### PR DESCRIPTION
## Summary

Implements the initial `ros2launch_session` package — a standalone, reusable API for managed ROS 2 launch sessions.

- Extracts the 4-handler wiring pattern from `launch_testing`'s `_RunnerWorker` into a clean `LaunchSession` class
- Two modes: standalone (`run()` with `on_ready` callback) and external service (`from_service()` context manager)
- Thread-safe process startup/shutdown monitoring via `ActiveProcInfoHandler`
- Output capture and pattern matching via `ActiveIoHandler`
- `ProcessProxy` integration for fine-grained process control
- Clean shutdown via LaunchService's existing SIGINT → SIGTERM → SIGKILL escalation

Composes existing `launch` and `launch_testing` APIs — no custom signal handling, no custom process management.

Closes #1

## Test plan

- [x] Package builds with `colcon build --packages-select ros2launch_session`
- [x] All 6 tests pass (copyright, flake8, pep257 + 3 functional tests)
- [x] `test_echo_and_shutdown` — verifies output capture and clean exit
- [x] `test_shutdown_long_running_process` — verifies shutdown of long-running process
- [x] `test_run_not_allowed_on_borrowed_service` — verifies run() rejects borrowed service

---
**Authored-By**: `Claude Code Agent`
**Model**: `Claude Opus 4.6`
